### PR TITLE
[README update]: 添加 imagemagick 依赖到 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cd imx-forge
 
 # 2. 安装依赖（Ubuntu/WSL2）
 sudo apt install -y build-essential gcc make bison flex device-tree-compiler \
-    libssl-dev libncurses-dev python3-pyelftools swig picocom
+    libssl-dev libncurses-dev python3-pyelftools swig picocom imagemagick
 
 # 3. 安装 ARM 工具链（ARM GNU Toolchain 15.2）
 wget https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-linux-gnueabihf.tar.xz


### PR DESCRIPTION
缺少 imagemagick 会导致构建 U-Boot logo 时报错：
Error: ImageMagick (convert) not found.

该工具用于将 PNG logo 转换为 BMP 格式。