### PR TITLE
[script] Stage 4 don't need to clean directory

### DIFF
--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -296,7 +296,8 @@ main() {
 
     # Create build output directory
     # If release-latest exists, rename it to release-{datetime}
-    if [[ -d "${BUILD_OUTPUT_DIR}" ]]; then
+    # Note: Stage 4 should not clear the folder, as it depends on previous stages
+    if [[ -d "${BUILD_OUTPUT_DIR}" && "${SPECIFIC_STAGE}" != "4" ]]; then
         local datetime=$(date +%Y%m%d-%H%M%S)
         local archive_dir="${PROJECT_ROOT}/out/release-${datetime}"
         log_info "Archiving existing ${BUILD_OUTPUT_DIR} -> ${archive_dir}"


### PR DESCRIPTION
Modify release-all.sh to avoid clearing the release-latest directory when running Stage 4 only.