### PR TITLE
Fix/03 uboot porting overview md fix

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,11 @@
 - **GitHub**: [Heizer-Tan](https://github.com/Heizer-Tan)
 - **贡献**: README 修正、脚本优化
 
+### Anonymous
+- Anonymous (via email: 85.hear.blimps@icloud.com)
+- **贡献**: 指出了 U-Boot 教程中关于自定义命令添加的文档疏漏，包括 Makefile 配置和头文件引用问题
+
+
 ---
 
 ## 如何成为贡献者

--- a/document/tutorial/uboot/03_uboot_porting_overview.md
+++ b/document/tutorial/uboot/03_uboot_porting_overview.md
@@ -459,10 +459,15 @@ ls include/configs/ | grep mx6ull
 
 U-Boot命令行里的命令（boot、md、mw、dhcp、tftp）都在这。如果你要添加自定义命令，在这里加。
 
-比如你想添加一个hello命令：
+比如你想添加一个hello命令，需要完成以下步骤：
+
+**第一步：创建hello.c文件**
+
+在`cmd/`目录下创建`hello.c`文件：
+
 ```c
-#include <common.h>
 #include <command.h>
+#include <stdio.h>
 
 static int do_hello(struct cmd_tbl *cmdtp, int flag, int argc,
                    char *const argv[])
@@ -478,7 +483,31 @@ U_BOOT_CMD(
 );
 ```
 
-把这个文件保存为cmd/hello.c，重新编译，U-Boot就有hello命令了。
+> **注意**：在U-Boot 2025.04等新版本中，`<common.h>`头文件已经不可用，正确的头文件是`<command.h>`和`<stdio.h>`。如果使用旧的头文件会导致编译失败。
+
+**第二步：修改cmd/Makefile**
+
+仅将hello.c放入cmd/目录并不会自动参与编译，还需要在`cmd/Makefile`中显式添加。打开`cmd/Makefile`文件，在适当位置添加：
+
+```makefile
+obj-y += hello.o
+```
+
+或者更规范的方式（如果命令支持配置选项）：
+
+```makefile
+obj-$(CONFIG_CMD_HELLO) += hello.o
+```
+
+**第三步：重新编译**
+
+```bash
+make -j$(nproc)
+```
+
+编译完成后，U-Boot就有hello命令了。
+
+> **重要提示**：如果不修改Makefile，即使hello.c文件存在，也不会生成对应的目标文件，命令不会出现在U-Boot命令列表中。这是初学者容易遇到的常见问题。
 
 `common/` —— **通用功能代码**
 


### PR DESCRIPTION
## 问题描述

感谢社区贡献者 Anonymous (85.hear.blimps@icloud.com) 指出 U-Boot 教程中关于添加自定义命令的文档存在疏漏：

1. **编译配置缺失**：文档中仅提到将 hello.c 放入 cmd/ 目录，未说明需要在 cmd/Makefile 中显式添加编译规则，导致初学者出现"代码已添加但命令不可用"的问题

2. **头文件引用错误**：文档中使用 `<common.h>` 在 U-Boot 2025.04 等新版本中已不可用，导致编译失败

## 修复内容

- [x] 修正头文件引用：`<common.h>` → `<command.h>` + `<stdio.h>`
- [x] 添加 Makefile 修改步骤：明确说明需要添加 `obj-y += hello.o`
- [x] 完善流程说明：将过程分为三个清晰步骤（创建文件 → 修改Makefile → 编译）
- [x] 添加警告提示：说明常见错误和注意事项
- [x] 更新贡献者列表：记录此次文档改进的贡献

## 影响范围

- `document/tutorial/uboot/03_uboot_porting_overview.md`
- `CONTRIBUTORS.md`

## 测试验证

已通过检查 U-Boot 2025.04 源码验证：
- ✅ cmd/Makefile 中所有命令均使用 `obj-$(CONFIG_CMD_XXX)` 格式
- ✅ cmd/ 目录下现有命令均使用 `<command.h>` 而非 `<common.h>`
- ✅ printf 函数声明位于 `<stdio.h>` 中
