### PR TITLE
fix ./scripts/driver_helper/build_driver.sh example-driver --kernel=imx

### DIFF
--- a/scripts/build_helper/build-linux.sh
+++ b/scripts/build_helper/build-linux.sh
@@ -27,6 +27,9 @@ else
     log_cmd() { echo -e "${YELLOW}[CMD]${NC} $1"; }
 fi
 
+# 导入依赖检查脚本
+source "${SCRIPT_DIR}/../init/env-init.sh"
+
 # Configuration
 ARCH=arm
 CROSS_COMPILE=arm-none-linux-gnueabihf-
@@ -56,115 +59,7 @@ log_info "Using ${NPROC} parallel jobs"
 
 # Check host dependencies
 check_host_dependencies() {
-    log_info "Checking host dependencies..."
-
-    MISSING_PKGS=()
-    FOUND_PKGS=()
-
-    # Helper: check if command exists
-    check_cmd() {
-        local cmd=$1
-        local pkg=$2
-        if command -v ${cmd} &> /dev/null; then
-            FOUND_PKGS+=("${pkg}")
-            return 0
-        else
-            MISSING_PKGS+=("${pkg}")
-            return 1
-        fi
-    }
-
-    # Helper: check if dpkg package is installed
-    check_dpkg() {
-        local pkg=$1
-        if dpkg -s ${pkg} &> /dev/null; then
-            FOUND_PKGS+=("${pkg}")
-            return 0
-        else
-            MISSING_PKGS+=("${pkg}")
-            return 1
-        fi
-    }
-
-    # Helper: check if header file exists
-    check_header() {
-        local header=$1
-        local pkg=$2
-        if [ -f "${header}" ]; then
-            FOUND_PKGS+=("${pkg}")
-            return 0
-        else
-            MISSING_PKGS+=("${pkg}")
-            return 1
-        fi
-    }
-
-    # Helper: check Python module
-    check_python_module() {
-        local module=$1
-        local pkg=$2
-        if python3 -c "import ${module}" 2>/dev/null; then
-            FOUND_PKGS+=("${pkg}")
-            return 0
-        else
-            MISSING_PKGS+=("${pkg}")
-            return 1
-        fi
-    }
-
-    # Check build tools (use || true to prevent exit on set -e)
-    check_cmd gcc build-essential || true
-    check_cmd make build-essential || true
-    check_cmd bc bc || true
-    check_cmd bison bison || true
-    check_cmd flex flex || true
-    check_cmd dtc device-tree-compiler || true
-    check_cmd python3 python3 || true
-
-    # Check libssl via dpkg (more reliable than header check)
-    if dpkg -s libssl-dev &> /dev/null; then
-        FOUND_PKGS+=("libssl-dev")
-    else
-        MISSING_PKGS+=("libssl-dev")
-    fi
-
-    # Check libgnutls via dpkg or header
-    if dpkg -s libgnutls28-dev &> /dev/null || [ -f /usr/include/gnutls/gnutls.h ]; then
-        FOUND_PKGS+=("libgnutls28-dev")
-    else
-        MISSING_PKGS+=("libgnutls28-dev")
-    fi
-
-    # Check libncurses via dpkg or header
-    if dpkg -s libncurses-dev &> /dev/null || [ -f /usr/include/ncursesw/ncurses.h ] || [ -f /usr/include/ncurses/ncurses.h ]; then
-        FOUND_PKGS+=("libncurses-dev")
-    else
-        MISSING_PKGS+=("libncurses-dev")
-    fi
-
-    # Remove duplicates from FOUND_PKGS and MISSING_PKGS
-    FOUND_PKGS=($(echo "${FOUND_PKGS[@]}" | tr ' ' '\n' | sort -u))
-    MISSING_PKGS=($(echo "${MISSING_PKGS[@]}" | tr ' ' '\n' | sort -u))
-
-    # Display results
-    for pkg in "${FOUND_PKGS[@]}"; do
-        log_info "  ✓ ${pkg}"
-    done
-
-    for pkg in "${MISSING_PKGS[@]}"; do
-        log_warn "  ✗ ${pkg} (not found)"
-    done
-
-    if [ ${#MISSING_PKGS[@]} -gt 0 ]; then
-        log_error "Missing dependencies: ${MISSING_PKGS[*]}"
-        echo ""
-        log_info "Install missing packages with:"
-        echo -e "  ${YELLOW}sudo apt install ${MISSING_PKGS[*]}${NC}"
-        echo ""
-        exit 1
-    fi
-
-    log_info "All host dependencies found"
+    check_linux_dependencies || exit 1
 }
 
 # Check if toolchain exists
@@ -200,11 +95,13 @@ check_defconfig() {
     DEFCONFIG_FILE="${LINUX_SRC_DIR}/arch/arm/configs/${DEFCONFIG}"
 
     if [ ! -f "${DEFCONFIG_FILE}" ]; then
-        log_error "Defconfig file not found: ${DEFCONFIG_FILE}"
-        exit 1
+        log_warn "Defconfig file not found: ${DEFCONFIG_FILE}"
+        log_info "Will prepare defconfig from template"
+        return 1
     fi
 
     log_info "Defconfig found: ${DEFCONFIG_FILE}"
+    return 0
 }
 
 # Clean build
@@ -374,7 +271,14 @@ main() {
     # Pre-build checks
     check_host_dependencies
     check_toolchain
-    check_defconfig
+    
+    # Check defconfig and prepare if needed
+    if ! check_defconfig; then
+        prepare_defconfig || {
+            log_error "Failed to prepare defconfig"
+            exit 1
+        }
+    fi
 
     log_info "========================================"
     log_info "All checks passed, starting build..."

--- a/scripts/lib/driver_buildlib.sh
+++ b/scripts/lib/driver_buildlib.sh
@@ -155,7 +155,12 @@ check_kernel_built() {
         log_error ""
         log_error "   2. 或者使用快速编译（仅生成必要文件）："
         log_error "      cd $kdir"
-        log_error "      make O=$kobj ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE modules_prepare"
+        log_error "      make O=$kobj ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE vmlinux -j\$(nproc)"
+        log_error ""
+        log_error "📌 重要说明"
+        log_error "   你需要确保："
+        log_error "   1.1 至少编译过一次 vmlinux（或完整内核），以生成 Module.symvers"
+        log_error "   1.2. ln -s vmlinux.symvers $kobj/Module.symvers"
         log_error ""
         log_error "========================================"
         return 1


### PR DESCRIPTION
1、编译linux时，没有安装依赖可以通过脚本直接安装
2、没有进行过linux编译时，编译驱动会失败；modules_prepare 不会生成 Module.symvers 文件，快速编译命令从 modules_prepare 改为 vmlinux