### PR TITLE
fix: missing left sidebar to hyperfast navigate passages

### DIFF
--- a/project.config.ts
+++ b/project.config.ts
@@ -28,7 +28,14 @@ export default defineProject({
 
   sidebar: {
     volumes: [
-      { name: 'all', srcDir: '.', urlPrefix: '/' },
+      { name: 'tutorial', srcDir: 'tutorial', urlPrefix: '/tutorial' },
+      { name: 'architecture', srcDir: 'architecture', urlPrefix: '/architecture' },
+      { name: 'ci', srcDir: 'ci', urlPrefix: '/ci' },
+      { name: 'scripts', srcDir: 'scripts', urlPrefix: '/scripts' },
+      { name: 'development', srcDir: 'development', urlPrefix: '/development' },
+      { name: 'modules', srcDir: 'modules', urlPrefix: '/modules' },
+      { name: 'team', srcDir: 'team', urlPrefix: '/team' },
+      { name: 'todo', srcDir: 'todo', urlPrefix: '/todo' },
     ],
   },
 


### PR DESCRIPTION
Missing Sidebars, vitepress owns left sidebar to quickly jump among passages from up to down, but our configurations owns bugs, pr fix this

丢失左侧导航栏，现在已经修复，可以快速滑动查看文章啦！

当前：
<img width="2534" height="1378" alt="image" src="https://github.com/user-attachments/assets/9729e055-9442-472b-9b09-ad2b78046801" />

修改后

<img width="2559" height="1428" alt="image" src="https://github.com/user-attachments/assets/ff9853db-9804-4cc3-9a29-f7ed0fc78695" />

