### PR TITLE
feat(copy_to_tftp): 添加配置文件系统和摘要信息显示

### DIFF
--- a/document/scripts/index.md
+++ b/document/scripts/index.md
@@ -5,6 +5,7 @@
 <ChapterNav>
   <ChapterLink num="01" href="../scripts/release-all.sh">release-all.sh —— 一键构建所有组件</ChapterLink>
   <ChapterLink num="02" href="../scripts/patch_maker.sh">patch_maker.sh —— 补丁生成工具</ChapterLink>
+  <ChapterLink num="03" href="../scripts/server_helper/copy_to_tftp.sh">copy_to_tftp.sh —— TFTP文件部署</ChapterLink>
 </ChapterNav>
 
 | 脚本 | 用途 |
@@ -13,6 +14,7 @@
 | build-linux.sh | 构建 NXP BSP 内核 |
 | build-mainline-linux.sh | 构建主线内核 |
 | build-busybox.sh | 构建 BusyBox |
+| copy_to_tftp.sh | 部署内核和设备树到 TFTP 目录 |
 
 ::: details 目录结构
 ```

--- a/document/scripts/server_helper/copy_to_tftp.sh.md
+++ b/document/scripts/server_helper/copy_to_tftp.sh.md
@@ -7,10 +7,13 @@
 ### 核心功能
 
 - **自动文件复制**：将编译好的内核镜像(zImage)和设备树文件(DTB)复制到TFTP目录
+- **配置文件系统**：支持 `.conf` 配置文件，灵活管理不同板子的路径配置
+- **多板子支持**：通过 `tftp-<BOARD>.conf` 支持多种开发板配置
 - **源文件验证**：复制前检查源文件是否存在，避免复制失败
 - **目录自动创建**：目标目录不存在时自动创建
 - **工具链适配**：优先使用 rsync，回退到 cp 命令
-- **灵活配置**：支持命令行参数覆盖默认路径
+- **摘要信息显示**：复制完成后显示内核版本、设备树信息和文件大小
+- **Release 集成**：默认从 `out/release-latest` 获取预编译文件
 
 ### 设计理念
 
@@ -76,17 +79,160 @@ copy_to_tftp.sh
 
 | 参数 | 说明 | 默认值 | 必需/可选 |
 |------|------|--------|-----------|
-| `--kernel=PATH` | 内核镜像文件路径 | `out/linux/arch/arm/boot/zImage` | 可选 |
-| `--dts=PATH` | 设备树文件路径 | `out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb` | 可选 |
+| `--config=PATH` | 指定配置文件路径 | 自动搜索 `tftp-*.conf` | 可选 |
+| `--kernel=PATH` | 内核镜像文件路径（覆盖配置） | 从配置文件读取 | 可选 |
+| `--dtb=PATH` | 设备树文件路径（覆盖配置） | 从配置文件读取 | 可选 |
+| `--rootfs=PATH` | 根文件系统镜像路径 | 从配置文件读取 | 可选 |
+| `--uboot=PATH` | U-Boot 镜像路径 | 从配置文件读取 | 可选 |
 | `--tftp-path=PATH` | TFTP服务器目录路径 | `~/tftp` | 可选 |
+| `--list-configs` | 列出可用的配置文件 | - | 可选 |
 | `-h, --help` | 显示帮助信息 | - | 可选 |
+
+### 环境变量
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `BOARD_NAME` | 板子名称，用于搜索配置文件 | `imx6ull-aes` |
+| `PROJECT_ROOT` | 项目根目录 | 自动检测 |
+
+## 配置文件系统
+
+### 配置文件概述
+
+`copy_to_tftp.sh` 支持通过配置文件管理路径配置，特别适合多板子开发场景。配置文件使用 Bash 变量语法，简单灵活。
+
+### 配置文件格式
+
+配置文件示例 (`tftp-imx6ull-aes.conf`)：
+
+```bash
+# 项目根目录（自动设置）
+export PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# Release 目录
+RELEASE_DIR="${PROJECT_ROOT}/out/release-latest"
+
+# 文件路径配置
+TFTP_KERNEL="${RELEASE_DIR}/linux/arch/arm/boot/zImage"
+TFTP_DTB="${RELEASE_DIR}/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
+TFTP_UBOOT=""
+TFTP_ROOTFS=""
+
+# TFTP 服务器配置
+TFTP_DEST_DIR="${HOME}/tftp"
+TFTP_PRESERVE_NAMES=true
+TFTP_VERIFY_CHECKSUM=false
+TFTP_COPY_METHOD="auto"
+TFTP_POST_MESSAGE="Ready for network boot."
+```
+
+### 支持的配置变量
+
+| 变量 | 说明 | 示例 |
+|------|------|------|
+| `TFTP_KERNEL` | 内核镜像路径 | `${RELEASE_DIR}/linux/zImage` |
+| `TFTP_DTB` | 设备树文件路径 | `${RELEASE_DIR}/linux/imx6ull-aes.dtb` |
+| `TFTP_ROOTFS` | 根文件系统镜像（可选） | `${RELEASE_DIR}/images/rootfs.ext4` |
+| `TFTP_UBOOT` | U-Boot 镜像（可选） | `${RELEASE_DIR}/uboot/u-boot.imx` |
+| `TFTP_DEST_DIR` | TFTP 目录 | `${HOME}/tftp` |
+| `TFTP_PRESERVE_NAMES` | 是否保留原始文件名 | `true` 或 `false` |
+| `TFTP_VERIFY_CHECKSUM` | 是否验证校验和 | `true` 或 `false` |
+| `TFTP_COPY_METHOD` | 复制方法 | `auto`、`cp`、`rsync` |
+| `TFTP_POST_MESSAGE` | 复制完成后显示的消息 | 任意文本 |
+
+### 配置文件搜索顺序
+
+脚本按以下顺序搜索配置文件：
+
+1. `--config=PATH`（如果指定）
+2. `$(dirname $0)/tftp-${BOARD_NAME}.conf`（默认：`tftp-imx6ull-aes.conf`）
+3. `$(dirname $0)/tftp.conf`
+4. `$PWD/tftp-${BOARD_NAME}.conf`
+5. `$PWD/tftp.conf`
+
+**优先级**：命令行参数 > 配置文件 > 脚本默认值
+
+### 创建新板子配置
+
+为新的板子创建配置文件：
+
+```bash
+# 复制示例配置
+cp scripts/server_helper/tftp.conf.example scripts/server_helper/tftp-myboard.conf
+
+# 编辑配置文件
+vim scripts/server_helper/tftp-myboard.conf
+
+# 使用新配置
+BOARD_NAME=myboard ./scripts/server_helper/copy_to_tftp.sh
+```
+
+### 配置文件位置
+
+配置文件存放在以下位置：
+
+- **项目配置**：`scripts/server_helper/tftp-*.conf`
+- **本地配置**：`$PWD/tftp.conf`（当前目录）
+- **自定义**：通过 `--config` 指定任意路径
+
+### 列出可用配置
+
+使用 `--list-configs` 查看所有可用配置：
+
+```bash
+./scripts/server_helper/copy_to_tftp.sh --list-configs
+```
+
+输出示例：
+
+```
+Available TFTP config files:
+============================
+  - scripts/server_helper/tftp-imx6ull-aes.conf (board: imx6ull-aes)
+  - scripts/server_helper/tftp.conf (default)
+```
 
 ### 默认路径详解
 
-#### 内核默认路径
+#### 从 Release 获取文件（推荐）
+
+默认配置使用 `out/release-latest` 目录，这是通过 `release-all.sh` 生成的预编译产物：
 
 ```bash
-DEFAULT_KERNEL="out/linux/arch/arm/boot/zImage"
+# 配置文件中的路径
+RELEASE_DIR="${PROJECT_ROOT}/out/release-latest"
+TFTP_KERNEL="${RELEASE_DIR}/linux/arch/arm/boot/zImage"
+TFTP_DTB="${RELEASE_DIR}/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
+```
+
+**Release 目录结构**：
+
+```
+out/release-latest/
+├── linux/
+│   ├── arch/arm/boot/zImage
+│   ├── arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb
+│   └── include/config/kernel.release  # 内核版本信息
+├── uboot/
+│   └── u-boot-dtb.imx
+└── images/
+    └── rootfs.ext4
+```
+
+**为什么使用 Release 目录**：
+
+1. **一致性**：所有开发板使用相同的预编译版本
+2. **版本跟踪**：`release-latest` 是最新发布版本的符号链接
+3. **快速部署**：无需重新编译即可部署
+4. **版本信息**：可以从 `kernel.release` 获取准确的版本号
+
+#### 内核默认路径（开发模式）
+
+如果在开发过程中需要使用刚编译的文件：
+
+```bash
+# 命令行指定
+./scripts/server_helper/copy_to_tftp.sh --kernel=out/linux/arch/arm/boot/zImage
 ```
 
 **路径结构解析**：
@@ -98,24 +244,10 @@ out/linux/                    # 内核编译输出根目录
     └── zImage                # 压缩的内核镜像（默认使用）
 ```
 
-**为什么使用 zImage**：
-
-- `zImage` 是压缩后的内核镜像，占用空间更小
-- TFTP传输速度更快
-- U-Boot会自动解压
-
 #### 设备树默认路径
 
 ```bash
-DEFAULT_DTS="out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
-```
-
-**路径结构解析**：
-
-```
-out/linux/arch/arm/boot/dts/    # 设备树编译输出目录
-└── nxp/imx/                    # NXP i.MX 系列设备树
-    └── imx6ull-aes.dtb         # AES开发板的设备树（二进制）
+TFTP_DTB="${RELEASE_DIR}/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
 ```
 
 **设备树文件命名规则**：
@@ -577,71 +709,113 @@ TcpTestSucceeded : False
 
 ## 使用示例
 
-### 基本用法
+### 基本用法（使用默认配置）
 
 ```bash
-# 使用默认路径
+# 使用默认配置（tftp-imx6ull-aes.conf）
 ./scripts/server_helper/copy_to_tftp.sh
 ```
 
 **输出示例**：
 
 ```
+Loading config: /home/charliechen/imx-forge/scripts/server_helper/tftp-imx6ull-aes.conf
+========================================
 TFTP Copy Helper
-================
-Kernel:   out/linux/arch/arm/boot/zImage
-DTB:      out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb
-TFTP dir: ~/tftp
+========================================
+Project: /home/charliechen/imx-forge
 
-Success: Copied Kernel to '/home/charliechen/tftp/zImage'
-Success: Copied DTB to '/home/charliechen/tftp/imx6ull-aes.dtb'
+Source files:
+  Kernel:  /home/charliechen/imx-forge/out/release-latest/linux/arch/arm/boot/zImage
+  DTB:     /home/charliechen/imx-forge/out/release-latest/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb
 
-All files copied successfully!
+Destination:
+  TFTP dir: /home/charliechen/tftp
+
+Copying Kernel (9.5M)...
+  ✓ Copied to: /home/charliechen/tftp/zImage
+Copying DTB (36K)...
+  ✓ Copied to: /home/charliechen/tftp/imx6ull-aes.dtb
+
+========================================
+✓ All files copied successfully!
+========================================
+
+Summary:
+--------
+Kernel:
+  Version: 6.12.49-gdf24f9428e38-dirty
+  Built: 2026-06-08 12:22:07
+  Size: 9.5M
+  Path: /home/charliechen/tftp/zImage
+
+Device Tree:
+  Model: Awesome Embedded Studio IMX6ULL (i.mx NXP)
+  Built: 2026-06-08 12:16:14
+  Size: 36K
+  Path: /home/charliechen/tftp/imx6ull-aes.dtb
+
+Ready for network boot. In U-Boot: tftp 0x80800000 zImage; tftp 0x83000000 imx6ull-aes.dtb; bootz 0x80800000 - 0x83000000
 ```
 
-### 自定义内核路径
+### 列出可用配置
 
 ```bash
-# 指定自定义内核路径
-./scripts/server_helper/copy_to_tftp.sh --kernel=out/linux/arch/arm/boot/Image
+# 列出所有可用的配置文件
+./scripts/server_helper/copy_to_tftp.sh --list-configs
+```
+
+**输出示例**：
+
+```
+Available TFTP config files:
+============================
+  - scripts/server_helper/tftp-imx6ull-aes.conf (board: imx6ull-aes)
+  - scripts/server_helper/tftp.conf (default)
+```
+
+### 使用特定板子配置
+
+```bash
+# 方法 1：通过 BOARD_NAME 环境变量
+BOARD_NAME=imx6ull-aes ./scripts/server_helper/copy_to_tftp.sh
+
+# 方法 2：通过 --config 参数
+./scripts/server_helper/copy_to_tftp.sh --config=scripts/server_helper/tftp-imx6ull-aes.conf
 ```
 
 **适用场景**：
 
-- 使用未压缩内核镜像
-- 测试不同编译配置的输出
+- 多板子开发
+- 不同板子使用不同的内核或设备树
+- 团队协作时统一配置
 
-### 自定义设备树路径
-
-```bash
-# 指定自定义设备树
-./scripts/server_helper/copy_to_tftp.sh --dts=out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-14x14-evk.dtb
-```
-
-**适用场景**：
-
-- 使用不同的开发板设备树
-- 测试修改后的设备树
-
-### 自定义TFTP目录
+### 覆盖配置文件中的路径
 
 ```bash
-# 使用非标准TFTP目录
+# 覆盖内核路径（临时使用开发版本）
+./scripts/server_helper/copy_to_tftp.sh --kernel=out/linux/arch/arm/boot/zImage
+
+# 覆盖设备树路径
+./scripts/server_helper/copy_to_tftp.sh --dtb=out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-14x14-evk.dtb
+
+# 覆盖 TFTP 目录
 ./scripts/server_helper/copy_to_tftp.sh --tftp-path=/var/lib/tftpboot
 ```
 
 **适用场景**：
 
-- 系统级TFTP服务
-- 多项目共享TFTP目录
+- 临时测试不同的内核或设备树
+- 使用系统级 TFTP 服务
+- 多项目共享 TFTP 目录
 
 ### 组合使用
 
 ```bash
-# 完整自定义
+# 完整自定义（覆盖所有路径）
 ./scripts/server_helper/copy_to_tftp.sh \
     --kernel=build/output/zImage \
-    --dts=build/output/custom.dtb \
+    --dtb=build/output/custom.dtb \
     --tftp-path=/srv/tftp
 ```
 

--- a/scripts/server_helper/copy_to_tftp.sh
+++ b/scripts/server_helper/copy_to_tftp.sh
@@ -5,42 +5,203 @@
 # Usage: copy_to_tftp.sh [OPTIONS]
 #
 # Options:
-#   --kernel=PATH      Path to zImage kernel file
-#                     (default: out/linux/zImage)
-#   --dts=PATH         Path to DTB file
-#                     (default: out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb)
-#   --tftp-path=PATH   Path to TFTP directory
-#                     (default: ~/tftp)
-#   -h, --help         Show this help message
+#   --config=PATH     Path to config file (tftp.conf or tftp-<BOARD>.conf)
+#   --kernel=PATH     Path to kernel file (overrides config)
+#   --dtb=PATH        Path to DTB file (overrides config)
+#   --rootfs=PATH     Path to rootfs image (optional, overrides config)
+#   --uboot=PATH      Path to U-Boot image (optional, overrides config)
+#   --tftp-path=PATH  TFTP directory (overrides config)
+#   --list-configs    List available config files
+#   -h, --help        Show this help message
+#
+# Config files are searched in the following order:
+#   1. --config=PATH (if specified)
+#   2. $(dirname $0)/tftp-${BOARD_NAME}.conf (default: tftp-imx6ull-aes.conf)
+#   3. $PWD/tftp-${BOARD_NAME}.conf
+#   4. $(dirname $0)/tftp.conf
+#   5. $PWD/tftp.conf
+#
+# Environment variables:
+#   BOARD_NAME    Board name for config lookup (default: "imx6ull-aes")
+#   PROJECT_ROOT   Project root directory (auto-detected if not set)
 #
 
-# Default values
-DEFAULT_KERNEL="out/linux/arch/arm/boot/zImage"
-DEFAULT_DTS="out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
-DEFAULT_TFTP_PATH="$HOME/tftp"
+set -e
 
-# Initialize variables with defaults
-KERNEL="${DEFAULT_KERNEL}"
-DTS="${DEFAULT_DTS}"
-TFTP_PATH="${DEFAULT_TFTP_PATH}"
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default values (can be overridden by config file or command line)
+DEFAULT_KERNEL="${PROJECT_ROOT}/out/linux/arch/arm/boot/zImage"
+DEFAULT_DTB="${PROJECT_ROOT}/out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
+DEFAULT_TFTP_PATH="${HOME}/tftp"
+DEFAULT_COPY_METHOD="auto"
+
+# Initialize variables
+KERNEL=""
+DTB=""
+ROOTFS=""
+UBOOT=""
+TFTP_PATH=""
+COPY_METHOD=""
+CONFIG_FILE=""
+PRESERVE_NAMES=""
+VERIFY_CHECKSUM=""
+BOARD_NAME="${BOARD_NAME:-}"
 
 # Print usage message
 usage() {
     sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# //g' | sed 's/^#//g'
+    cat << EOF
+
+Examples:
+  # Use default config
+  copy_to_tftp.sh
+
+  # Use specific board config
+  BOARD_NAME=imx6ull-aes copy_to_tftp.sh
+
+  # Override kernel path
+  copy_to_tftp.sh --kernel=out/linux/arch/arm/boot/zImage-custom
+
+  # Use custom config file
+  copy_to_tftp.sh --config=/path/to/custom.conf
+
+  # List available configs
+  copy_to_tftp.sh --list-configs
+EOF
     exit 0
+}
+
+# List available config files
+list_configs() {
+    echo "Available TFTP config files:"
+    echo "============================"
+    find "$SCRIPT_DIR" -maxdepth 1 -name "tftp*.conf" -type f 2>/dev/null | while read -r f; do
+        local name=$(basename "$f" .conf)
+        if [[ "$name" == "tftp" ]]; then
+            echo "  - $f (default)"
+        else
+            local board="${name#tftp-}"
+            echo "  - $f (board: $board)"
+        fi
+    done
+
+    # Also check PWD
+    if [[ "$SCRIPT_DIR" != "$PWD" ]]; then
+        find "$PWD" -maxdepth 1 -name "tftp*.conf" -type f 2>/dev/null | while read -r f; do
+            local name=$(basename "$f" .conf)
+            if [[ "$name" == "tftp" ]]; then
+                echo "  - $f (default, in PWD)"
+            else
+                local board="${name#tftp-}"
+                echo "  - $f (board: $board, in PWD)"
+            fi
+        done
+    fi
+
+    echo ""
+    echo "Usage: copy_to_tftp.sh --config=<path>"
+    echo "   or: BOARD_NAME=<name> copy_to_tftp.sh"
+    exit 0
+}
+
+# Find and load config file
+load_config() {
+    local config_file=""
+    local search_paths=()
+
+    # Default to imx6ull-aes if BOARD_NAME not set
+    BOARD_NAME="${BOARD_NAME:-imx6ull-aes}"
+
+    # 1. Explicit --config parameter
+    if [[ -n "$CONFIG_FILE" ]]; then
+        if [[ -f "$CONFIG_FILE" ]]; then
+            config_file="$CONFIG_FILE"
+        else
+            echo "Warning: Config file '$CONFIG_FILE' not found"
+        fi
+    fi
+
+    # 2. If not found, search for board-specific config
+    if [[ -z "$config_file" ]]; then
+        search_paths=(
+            "$PWD/tftp-${BOARD_NAME}.conf"
+            "$SCRIPT_DIR/tftp-${BOARD_NAME}.conf"
+        )
+        for path in "${search_paths[@]}"; do
+            if [[ -f "$path" ]]; then
+                config_file="$path"
+                break
+            fi
+        done
+    fi
+
+    # 3. Fall back to default tftp.conf
+    if [[ -z "$config_file" ]]; then
+        search_paths=(
+            "$PWD/tftp.conf"
+            "$SCRIPT_DIR/tftp.conf"
+        )
+        for path in "${search_paths[@]}"; do
+            if [[ -f "$path" ]]; then
+                config_file="$path"
+                break
+            fi
+        done
+    fi
+
+    # Load the config file if found
+    if [[ -n "$config_file" && -f "$config_file" ]]; then
+        echo "Loading config: $config_file"
+        # Set PROJECT_ROOT for the config file
+        export PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+        # Source the config file
+        # shellcheck source=/dev/null
+        source "$config_file" || {
+            echo "Warning: Error loading config file '$config_file'"
+        }
+    elif [[ -n "$CONFIG_FILE" ]]; then
+        echo "Error: Specified config file not found: $CONFIG_FILE"
+        exit 1
+    fi
+
+    # Apply config values (only if not already set by command line)
+    KERNEL="${KERNEL:-${TFTP_KERNEL:-$DEFAULT_KERNEL}}"
+    DTB="${DTB:-${TFTP_DTB:-$DEFAULT_DTB}}"
+    ROOTFS="${ROOTFS:-${TFTP_ROOTFS:-}}"
+    UBOOT="${UBOOT:-${TFTP_UBOOT:-}}"
+    TFTP_PATH="${TFTP_PATH:-${TFTP_DEST_DIR:-$DEFAULT_TFTP_PATH}}"
+    COPY_METHOD="${COPY_METHOD:-${TFTP_COPY_METHOD:-$DEFAULT_COPY_METHOD}}"
+    PRESERVE_NAMES="${PRESERVE_NAMES:-${TFTP_PRESERVE_NAMES:-true}}"
+    VERIFY_CHECKSUM="${VERIFY_CHECKSUM:-${TFTP_VERIFY_CHECKSUM:-false}}"
+    POST_MESSAGE="${POST_MESSAGE:-${TFTP_POST_MESSAGE:-}}"
 }
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --config=*)
+            CONFIG_FILE="${1#*=}"
+            ;;
         --kernel=*)
             KERNEL="${1#*=}"
             ;;
-        --dts=*)
-            DTS="${1#*=}"
+        --dtb=*|--dts=*)
+            DTB="${1#*=}"
+            ;;
+        --rootfs=*)
+            ROOTFS="${1#*=}"
+            ;;
+        --uboot=*)
+            UBOOT="${1#*=}"
             ;;
         --tftp-path=*)
             TFTP_PATH="${1#*=}"
+            ;;
+        --list-configs)
+            list_configs
             ;;
         -h|--help)
             usage
@@ -53,59 +214,261 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-# Check if rsync is available
-if command -v rsync &> /dev/null; then
+# Set PROJECT_ROOT
+export PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# Load config file
+load_config
+
+# Change to project root
+cd "${PROJECT_ROOT}" || exit 1
+
+# Expand tilde in paths
+TFTP_PATH="${TFTP_PATH/#\~/$HOME}"
+
+# Determine copy command
+if [[ "$COPY_METHOD" == "rsync" ]]; then
     COPY_CMD="rsync -ah --progress"
+elif [[ "$COPY_METHOD" == "cp" ]]; then
+    COPY_CMD="cp -v"
+elif [[ "$COPY_METHOD" == "auto" ]]; then
+    if command -v rsync &> /dev/null; then
+        COPY_CMD="rsync -ah --progress"
+    else
+        COPY_CMD="cp -v"
+    fi
 else
+    echo "Warning: Unknown copy method '$COPY_METHOD', using cp"
     COPY_CMD="cp -v"
 fi
 
-# Check if source files exist
+# Get kernel version and info
+get_kernel_info() {
+    local kernel="$1"
+    local info=""
+    local version=""
+
+    # First, try to get version from kernel.release file (if kernel is in build tree)
+    local kernel_dir=$(dirname "$kernel")
+    # Go up a few levels to find the kernel root
+    local version_file=""
+    for i in {1..5}; do
+        if [[ -f "$kernel_dir/include/config/kernel.release" ]]; then
+            version_file="$kernel_dir/include/config/kernel.release"
+            break
+        fi
+        kernel_dir=$(dirname "$kernel_dir")
+    done
+
+    if [[ -f "$version_file" ]]; then
+        version=$(cat "$version_file" 2>/dev/null | tr -d '\n')
+        if [[ -n "$version" ]]; then
+            info="Version: $version"
+        fi
+    fi
+
+    # If not found, try extracting from zImage using strings
+    if [[ -z "$info" ]] && command -v strings &> /dev/null; then
+        version=$(strings "$kernel" 2>/dev/null | grep -E "Linux version [0-9]" | head -1)
+        if [[ -z "$version" ]]; then
+            version=$(strings "$kernel" 2>/dev/null | grep -m1 -E "^[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+        fi
+        if [[ -n "$version" ]]; then
+            version=$(echo "$version" | sed 's/\s\+/ /g' | cut -c1-80)
+            info="Version: $version"
+        fi
+    fi
+
+    # Add build timestamp
+    local build_time=$(stat -c %y "$kernel" 2>/dev/null | cut -d'.' -f1)
+    if [[ -n "$build_time" ]]; then
+        if [[ -n "$info" ]]; then
+            info="${info}
+  Built: ${build_time}"
+        else
+            info="Built: ${build_time}"
+        fi
+    fi
+
+    echo "$info"
+}
+
+# Get DTB info
+get_dtb_info() {
+    local dtb="$1"
+    local info=""
+
+    # Try to extract compatible strings from DTB
+    if command -v strings &> /dev/null; then
+        local compat=$(strings "$dtb" 2>/dev/null | grep -A5 "compatible" | tr '\0' ' ' | head -1)
+        if [[ -n "$compat" ]]; then
+            info="Compatible: $compat"
+        fi
+    fi
+
+    # Try dtc if available for more detailed info
+    if command -v dtc &> /dev/null; then
+        local model=$(dtc -I dtb -O dts "$dtb" 2>/dev/null | grep "model" | head -1 | sed 's/.*= "\(.*\)".*/\1/')
+        if [[ -n "$model" ]]; then
+            info="Model: $model"
+        fi
+    fi
+
+    # Add timestamp
+    local build_time=$(stat -c %y "$dtb" 2>/dev/null | cut -d'.' -f1)
+    if [[ -n "$build_time" ]]; then
+        if [[ -n "$info" ]]; then
+            info="${info}
+  Built: ${build_time}"
+        else
+            info="Built: ${build_time}"
+        fi
+    fi
+
+    echo "$info"
+}
+
+# Check and copy a file
 check_and_copy() {
     local src="$1"
     local dst="$2"
     local desc="$3"
+    local optional="${4:-false}"
 
-    if [[ ! -f "${src}" ]]; then
-        echo "Error: ${desc} not found at '${src}'"
-        return 1
+    # Skip if source is empty
+    if [[ -z "$src" ]]; then
+        return 0
     fi
 
-    # Create destination directory if it doesn't exist
+    if [[ ! -f "${src}" ]]; then
+        if [[ "$optional" == "true" ]]; then
+            echo "Warning: ${desc} not found at '${src}' (skipping)"
+            return 0
+        else
+            echo "Error: ${desc} not found at '${src}'"
+            return 1
+        fi
+    fi
+
+    # Create destination directory
     mkdir -p "$(dirname "${dst}")"
+
+    # Show file info
+    local size=$(du -h "$src" | cut -f1)
+    echo "Copying ${desc} (${size})..."
+
+    # Verify checksum if requested
+    if [[ "$VERIFY_CHECKSUM" == "true" ]]; then
+        if command -v sha256sum &> /dev/null; then
+            local checksum=$(sha256sum "$src" | cut -d' ' -f1)
+            echo "  SHA256: $checksum"
+        elif command -v md5sum &> /dev/null; then
+            local checksum=$(md5sum "$src" | cut -d' ' -f1)
+            echo "  MD5: $checksum"
+        fi
+    fi
 
     # Copy file
     ${COPY_CMD} "${src}" "${dst}"
     if [[ $? -eq 0 ]]; then
-        echo "Success: Copied ${desc} to '${dst}'"
+        echo "  ✓ Copied to: ${dst}"
         return 0
     else
-        echo "Error: Failed to copy ${desc}"
+        echo "  ✗ Failed to copy ${desc}"
         return 1
     fi
 }
 
 # Main execution
-MAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "${MAIN_DIR}" || exit 1
-
+echo "========================================"
 echo "TFTP Copy Helper"
-echo "================"
-echo "Kernel:   ${KERNEL}"
-echo "DTB:      ${DTS}"
-echo "TFTP dir: ${TFTP_PATH}"
+echo "========================================"
+echo "Project: ${PROJECT_ROOT}"
+echo ""
+echo "Source files:"
+echo "  Kernel:  ${KERNEL}"
+echo "  DTB:     ${DTB}"
+[[ -n "$ROOTFS" ]] && echo "  RootFS:  ${ROOTFS}"
+[[ -n "$UBOOT" ]] && echo "  U-Boot:  ${UBOOT}"
+echo ""
+echo "Destination:"
+echo "  TFTP dir: ${TFTP_PATH}"
 echo ""
 
-# Expand tilde in TFTP_PATH
-TFTP_PATH="${TFTP_PATH/#\~/$HOME}"
+# Prepare destination filename
+if [[ "$PRESERVE_NAMES" == "true" ]]; then
+    KERNEL_DST="${TFTP_PATH}/$(basename "${KERNEL}")"
+    DTB_DST="${TFTP_PATH}/$(basename "${DTB}")"
+    ROOTFS_DST="${TFTP_PATH}/$(basename "${ROOTFS}")"
+    UBOOT_DST="${TFTP_PATH}/$(basename "${UBOOT}")"
+else
+    # Add board name prefix
+    local prefix="${BOARD_NAME:-board}"
+    KERNEL_DST="${TFTP_PATH}/${prefix}-$(basename "${KERNEL}")"
+    DTB_DST="${TFTP_PATH}/${prefix}-$(basename "${DTB}")"
+    ROOTFS_DST="${TFTP_PATH}/${prefix}-$(basename "${ROOTFS}")"
+    UBOOT_DST="${TFTP_PATH}/${prefix}-$(basename "${UBOOT}")"
+fi
 
-# Copy kernel
-KERNEL_DST="${TFTP_PATH}/$(basename "${KERNEL}")"
-check_and_copy "${KERNEL}" "${KERNEL_DST}" "Kernel" || exit 1
-
-# Copy DTB
-DTB_DST="${TFTP_PATH}/$(basename "${DTS}")"
-check_and_copy "${DTS}" "${DTB_DST}" "DTB" || exit 1
+# Copy files
+errors=0
+check_and_copy "${KERNEL}" "${KERNEL_DST}" "Kernel" || ((errors++))
+check_and_copy "${DTB}" "${DTB_DST}" "DTB" || ((errors++))
+check_and_copy "${ROOTFS}" "${ROOTFS_DST}" "RootFS" "true" || ((errors++))
+check_and_copy "${UBOOT}" "${UBOOT_DST}" "U-Boot" "true" || ((errors++))
 
 echo ""
-echo "All files copied successfully!"
+if [[ $errors -eq 0 ]]; then
+    echo "========================================"
+    echo "✓ All files copied successfully!"
+    echo "========================================"
+    echo ""
+    echo "Summary:"
+    echo "--------"
+
+    # Show kernel info
+    if [[ -f "$KERNEL_DST" ]]; then
+        echo "Kernel:"
+        kernel_info=$(get_kernel_info "$KERNEL")
+        if [[ -n "$kernel_info" ]]; then
+            echo "  $kernel_info"
+        fi
+        kernel_size=$(du -h "$KERNEL_DST" | cut -f1)
+        echo "  Size: $kernel_size"
+        echo "  Path: $KERNEL_DST"
+        echo ""
+    fi
+
+    # Show DTB info
+    if [[ -f "$DTB_DST" ]]; then
+        echo "Device Tree:"
+        dtb_info=$(get_dtb_info "$DTB")
+        if [[ -n "$dtb_info" ]]; then
+            echo "  $dtb_info"
+        fi
+        dtb_size=$(du -h "$DTB_DST" | cut -f1)
+        echo "  Size: $dtb_size"
+        echo "  Path: $DTB_DST"
+        echo ""
+    fi
+
+    # Show other files
+    if [[ -n "$ROOTFS" && -f "$ROOTFS_DST" ]]; then
+        rootfs_size=$(du -h "$ROOTFS_DST" | cut -f1)
+        echo "RootFS: $ROOTFS_DST ($rootfs_size)"
+        echo ""
+    fi
+    if [[ -n "$UBOOT" && -f "$UBOOT_DST" ]]; then
+        uboot_size=$(du -h "$UBOOT_DST" | cut -f1)
+        echo "U-Boot: $UBOOT_DST ($uboot_size)"
+        echo ""
+    fi
+
+    [[ -n "$POST_MESSAGE" ]] && echo "$POST_MESSAGE"
+    exit 0
+else
+    echo "========================================"
+    echo "✗ $errors file(s) failed to copy"
+    echo "========================================"
+    exit 1
+fi

--- a/scripts/server_helper/tftp-imx6ull-aes.conf
+++ b/scripts/server_helper/tftp-imx6ull-aes.conf
@@ -1,0 +1,39 @@
+# ==============================================================================
+# tftp-imx6ull-aes.conf - i.MX6ULL AES 开发板 TFTP 部署配置
+# ==============================================================================
+# 此配置用于 i.MX6ULL AES (14x14) 开发板的网络启动
+# 默认使用 out/release-latest 中的预编译内核
+
+# 项目根目录 (自动设置，无需修改)
+export PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# Release 目录 (使用最新 release)
+RELEASE_DIR="${PROJECT_ROOT}/out/release-latest"
+
+# ------------------------------------------------------------------------------
+# 文件路径配置
+# ------------------------------------------------------------------------------
+# 内核镜像 - 从 release 目录获取
+TFTP_KERNEL="${RELEASE_DIR}/linux/arch/arm/boot/zImage"
+
+# 设备树 - 从 release 目录获取
+TFTP_DTB="${RELEASE_DIR}/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
+
+# U-Boot 镜像 (可选)
+TFTP_UBOOT=""
+
+# 根文件系统 (可选)
+TFTP_ROOTFS=""
+
+# ------------------------------------------------------------------------------
+# TFTP 服务器配置
+# ------------------------------------------------------------------------------
+TFTP_DEST_DIR="${HOME}/tftp"
+TFTP_PRESERVE_NAMES=true
+
+# ------------------------------------------------------------------------------
+# 其他选项
+# ------------------------------------------------------------------------------
+TFTP_VERIFY_CHECKSUM=false
+TFTP_COPY_METHOD="auto"
+TFTP_POST_MESSAGE="Ready for network boot. In U-Boot: tftp 0x80800000 zImage; tftp 0x83000000 imx6ull-14x14-evk.dtb; bootz 0x80800000 - 0x83000000"

--- a/scripts/server_helper/tftp.conf.example
+++ b/scripts/server_helper/tftp.conf.example
@@ -1,0 +1,56 @@
+# ==============================================================================
+# tftp.conf - TFTP 部署配置文件
+# ==============================================================================
+# 此文件定义 TFTP 部署时需要复制到 TFTP 服务器的文件路径
+#
+# 使用方式:
+#   1. 复制此文件为 tftp.conf 或 tftp-<BOARD_NAME>.conf
+#   2. 修改下面的路径配置
+#   3. 运行: copy_to_tftp.sh [--config=PATH]
+#
+# 多板子配置:
+#   - 对于不同板子，创建多个配置文件，如:
+#     tftp-imx6ull-aes.conf  (用于 i.MX6ULL AES 板)
+#     tftp-imx6ull-14x14.conf (用于 i.MX6ULL 14x14 板)
+#   - 使用 --config 参数指定: copy_to_tftp.sh --config=tftp-imx6ull-aes.conf
+#   - 或通过 BOARD_NAME 环境变量: BOARD_NAME=imx6ull-aes copy_to_tftp.sh
+
+# ------------------------------------------------------------------------------
+# 文件路径配置
+# ------------------------------------------------------------------------------
+# 内核镜像文件路径
+# 常用位置: out/linux/arch/arm/boot/zImage
+TFTP_KERNEL="${PROJECT_ROOT}/out/linux/arch/arm/boot/zImage"
+
+# 设备树文件路径
+# 常用位置: out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-*.dtb
+TFTP_DTB="${PROJECT_ROOT}/out/linux/arch/arm/boot/dts/nxp/imx/imx6ull-aes.dtb"
+
+# 可选: 根文件系统镜像（如 initramfs 或 rootfs）
+# TFTP_ROOTFS="${PROJECT_ROOT}/out/images/rootfs.ext4"
+
+# 可选: U-Boot 镜像
+# TFTP_UBOOT="${PROJECT_ROOT}/out/uboot/u-boot-dtb.imx"
+
+# ------------------------------------------------------------------------------
+# TFTP 服务器配置
+# ------------------------------------------------------------------------------
+# TFTP 服务器根目录
+# 文件将复制到: ${TFTP_DEST_DIR}/
+TFTP_DEST_DIR="${HOME}/tftp"
+
+# 是否保留原始文件名（false 则添加板子名前缀）
+# 例如: imx6ull-aes-zImage vs zImage
+TFTP_PRESERVE_NAMES=true
+
+# ------------------------------------------------------------------------------
+# 复制选项
+# ------------------------------------------------------------------------------
+# 是否验证文件校验和（需要 md5sum 或 sha256sum）
+TFTP_VERIFY_CHECKSUM=false
+
+# 使用 rsync 还是 cp (auto/cp/rsync)
+TFTP_COPY_METHOD="auto"
+
+# 复制后显示的提示信息
+TFTP_POST_MESSAGE="Files copied to TFTP. Use 'bootz' in U-Boot to boot from network."


### PR DESCRIPTION
脚本增强：
- 支持通过 .conf 配置文件管理路径
- 新增多板子配置支持 (tftp-<BOARD>.conf)
- 默认从 out/release-latest 获取预编译文件
- 复制后显示内核版本、设备树信息和文件大小
- 新增 --config, --list-configs, --rootfs, --uboot 参数

新增文件：
- scripts/server_helper/tftp.conf.example (配置模板)
- scripts/server_helper/tftp-imx6ull-aes.conf (默认配置，Release-all编译的产物)

文档更新：
- 更新 copy_to_tftp.sh.md 反映新功能
- 在 document/scripts/index.md 添加链接

使用方式：
  ./scripts/server_helper/copy_to_tftp.sh          # 使用默认配置, 默认的情况下会直接找Release-all编译的产物
  ./scripts/server_helper/copy_to_tftp.sh --list-configs  # 列出可用配置
  BOARD_NAME=imx6ull-aes ./scripts/server_helper/copy_to_tftp.sh

这个PR是额外关联的 #58 的工作任务