### PR TITLE
fix: Qt 交叉编译 pipeline 静默吞掉致命失败 (#76)

### DIFF
--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -361,7 +361,8 @@ stage_4_rootfs() {
     log_info "RootFS directory: ${ROOTFS_DIR}"
     echo ""
     log_info "Running Command: ${SCRIPT_DIR}/varified_rootfs_ok.sh --rootfs-dir=${ROOTFS_DIR}"
-    bash "${SCRIPT_DIR}/varified_rootfs_ok.sh" --rootfs-dir="${ROOTFS_DIR}"
+    # varified_rootfs_ok.sh 失败时必须中止，否则会把残缺 rootfs 继续合 overlay 并制成镜像（issue #76）。
+    bash "${SCRIPT_DIR}/varified_rootfs_ok.sh" --rootfs-dir="${ROOTFS_DIR}" || { log_error "Stage 4: RootFS completion failed"; exit 1; }
 
     echo ""
     log_info "Merging Rootfs Overlay from rootfs/overlay/rootfs to ${ROOTFS_DIR}"

--- a/scripts/varified_rootfs_ok.sh
+++ b/scripts/varified_rootfs_ok.sh
@@ -320,6 +320,9 @@ run_third_party_installs() {
 
     log_info "Running third-party installation scripts..."
 
+    # 任一安装脚本失败将使本函数返回非零；循环仍继续以便一次看到所有失败，
+    # 但最终致命 —— 不再像过去那样 "continuing anyway" 后还打印 RootFS 成功（issue #76）。
+    local failed=0
     for script in "${scripts[@]}"; do
         local name
         name="$(basename "$script")"
@@ -332,11 +335,13 @@ run_third_party_installs() {
         if bash "$script"; then
             log_info "    ✓ $name completed"
         else
-            log_warn "    ✗ $name failed (continuing anyway)"
+            log_error "    ✗ $name failed"
+            failed=1
         fi
     done
 
     log_info "Third-party installations completed"
+    return $failed
 }
 
 # Verify rootfs completion
@@ -384,6 +389,51 @@ verify_rootfs() {
     fi
 }
 
+# Verify Qt artifacts (only invoked when third-party install actually ran).
+# 致命集：任何 Qt6 构建必产出的核心产物，缺失即判定 Qt 安装失败。
+# 软警告集：qmake 等 host 工具可能被裁剪部署，缺失只 warn 不致命。
+verify_qt_artifacts() {
+    local rootfs="$1"
+
+    log_info "Verifying Qt artifacts..."
+
+    local all_ok=1
+
+    # 致命：libQt6Core.so*（Qt6 核心 .so；glob 兼容 .so / .so.6 / .so.6.x.x）
+    local qt_core_hit
+    qt_core_hit=$(compgen -G "${rootfs}/usr/lib/libQt6Core.so*" 2>/dev/null | head -1)
+    if [[ -n "$qt_core_hit" ]]; then
+        log_debug "  ✓ libQt6Core.so found"
+    else
+        log_error "  ✗ libQt6Core.so* missing under ${rootfs}/usr/lib/"
+        all_ok=0
+    fi
+
+    # 致命：plugins/platforms/ 非空（target.conf 强制 FEATURE_linuxfb=ON，必有 libqlinuxfb.so）
+    local platforms_dir="${rootfs}/usr/lib/qt6/plugins/platforms"
+    if [[ -d "$platforms_dir" ]] && [[ -n "$(ls -A "$platforms_dir" 2>/dev/null)" ]]; then
+        log_debug "  ✓ Qt platform plugins present"
+    else
+        log_error "  ✗ Qt platform plugins missing or empty: ${platforms_dir}"
+        all_ok=0
+    fi
+
+    # 软警告：qmake（host 工具，裁剪部署可能省略）
+    if [[ -f "${rootfs}/usr/bin/qmake" ]] || [[ -f "${rootfs}/usr/bin/qmake6" ]]; then
+        log_debug "  ✓ qmake found"
+    else
+        log_warn "  ! qmake not found under ${rootfs}/usr/bin/ (host tool, may be stripped)"
+    fi
+
+    if [[ $all_ok -eq 1 ]]; then
+        log_info "Qt artifact verification passed"
+        return 0
+    else
+        log_error "Qt artifact verification failed"
+        return 1
+    fi
+}
+
 # Main function
 main() {
     # Handle help
@@ -425,12 +475,19 @@ main() {
 
     # Run third-party installations
     log_info "Step 5: Running third-party installations..."
-    run_third_party_installs "$ROOTFS_DIR"
+    run_third_party_installs "$ROOTFS_DIR" || { log_error "Third-party installation failed"; exit 1; }
     log_info ""
 
     # Verify
     log_info "Step 6: Verifying completion..."
-    verify_rootfs "$ROOTFS_DIR"
+    verify_rootfs "$ROOTFS_DIR" || { log_error "Rootfs verification failed"; exit 1; }
+
+    # Qt 产物校验：仅在第三方安装实际执行（未被 SKIP）且 install_qt_with_compile.sh 存在时进行，
+    # 避免误伤默认 CI（SKIP_THIRD_PARTY_INSTALL=true 时不装 Qt）。
+    if [[ "${SKIP_THIRD_PARTY_INSTALL:-false}" != "true" \
+        && -f "${THIRD_PARTY_INSTALL_DIR}/install_qt_with_compile.sh" ]]; then
+        verify_qt_artifacts "$ROOTFS_DIR" || { log_error "Qt artifact verification failed"; exit 1; }
+    fi
     log_info ""
 
     log_info "========================================"


### PR DESCRIPTION
## 修复 Issue #76

Qt 交叉编译 pipeline 静默吞掉致命失败：第三方库或 Qt 本身编译失败时仍打印 `RootFS completed successfully!` 并继续制成镜像（issue 诱因是 host 缺 meson 致 PulseAudio 没编出来，但任何第三方库失败都会复现）。

### 根因（横跨两个仓库）
1. **失败传播**：`manager.sh`（子模块）与 `varified_rootfs_ok.sh` 都用 `if cmd; then … else log_warn` 把致命失败降级（`log_warn` 返回 0），而 errexit 对 `if` 条件豁免，pipeline 不中止。
2. **门控失效**：`03-build-target-qt.sh` 用 `get-lib-path` 的返回值门控 `FEATURE_pulseaudio=ON`，但该函数只要 sysroot 下有 `usr/lib` 目录就返回路径（`third_party_init` 无条件创建它）→ 恒非空 → 没编 PulseAudio 也喂 `=ON` → Qt configure 硬错 `WrapPulseAudio_FOUND`。

### 改动

**子模块 `qt-compile-pipeline`（已直推其 main，本 PR bump pin → `3eba406`）**
- `manager.sh`：任一启用库安装失败现在 `exit 1`（`failed` 标志累加，循环仍继续编其余以暴露所有失败）；新增 `is-installed <lib>` 子命令。
- `03-build-target-qt.sh`：`FEATURE_pulseaudio`/`FEATURE_ffmpeg` 门控改用 `is-installed`，未装时显式 `=OFF`。
- `install-host-deps.sh`：`required_commands` 加 `meson`（原本漏检，缺 meson 时报虚假 “All required dependencies are installed”）。

**本仓库 `imx-forge`**
- `varified_rootfs_ok.sh`：`run_third_party_installs` 失败返回非零；`main` 失败 `exit 1`、不打印假成功横幅；新增 `verify_qt_artifacts`（致命：`libQt6Core.so*` + `qt6/plugins/platforms/` 非空；软警告：`qmake`），受 `SKIP_THIRD_PARTY_INSTALL != true && install_qt_with_compile.sh 存在` 双重门控，默认 CI（SKIP）不受影响。
- `release-all.sh`：stage_4 检查 `varified_rootfs_ok.sh` 退出码，失败时不继续 overlay 合并与镜像制作。

### 验证
- **子模块 Tier 0**：`is-installed` 退出码 0/1/2、`manager install` 失败→exit 1 / 成功→exit 0+标记生成，均通过。
- **本仓库 Tier 1**（stub 替换 third_party_install，trap 恢复）：
  - SKIP=true → exit 0 + 横幅，不查 Qt（保护默认 CI）
  - SKIP=false 无 Qt 产物 → exit 1（Qt 门控）
  - SKIP=false Qt 产物齐全 → exit 0 + 横幅（qmake 缺失只软警告）
  - SKIP=false 某安装脚本失败 → exit 1，不打印假成功横幅

### 不在本次范围
- `libsndfile` 变量名错配（`LIBSNDFILE_ENABLED` vs `SNDFILE_ENABLED`）与 #76 不同类，将另开 issue。
- `.github/workflows/ci-full.yml` 另行改进。
